### PR TITLE
Open floating window on press

### DIFF
--- a/content.js
+++ b/content.js
@@ -1685,6 +1685,15 @@
                     title: document.title
                 });
             }
+            if (request.action === 'toggleOverlay') {
+                try {
+                    toggleFloatingOverlay();
+                    sendResponse && sendResponse({ success: true });
+                } catch (e) {
+                    sendResponse && sendResponse({ success: false, error: e && e.message });
+                }
+                return true;
+            }
         });
     } catch (error) {
         console.log('Could not set up message listener:', error);

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,6 @@
     "scripting"
   ],
   "action": {
-    "default_popup": "popup.html",
     "default_title": "Meeting AI Assistant"
   },
   "background": {


### PR DESCRIPTION
Configure the extension icon to toggle the in-page floating overlay instead of opening a browser popup.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ea924f8-a90e-4d4d-8fb5-d64cf2735d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1ea924f8-a90e-4d4d-8fb5-d64cf2735d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

